### PR TITLE
Fixed markdown syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ required to complete them.
 | [10 User Interfaces](https://www.youtube.com/watch?v=Rz-rey4Q1bw&list=LL&index=6&t=8839s) | 10 User Interfaces using HTML, CSS and JavaScript| 1-Beginner |
 | [Audio Book](https://www.youtube.com/watch?v=Flm2YHEFd5A) | PDF to Audio Book using Python| 1-Beginner |
 | [Face Recognition App](https://www.youtube.com/watch?v=sz25xxF_AVE) | Face Recognition + Attendance using OpenCV| 1-Beginner |
-- [ Build Brand Page](https://www.youtube.com/watch?v=W7up-w1QYpw&ab_channel=DoSomeCoding)| Design with React| 1-Begineer |
+| [ Build Brand Page](https://www.youtube.com/watch?v=W7up-w1QYpw&ab_channel=DoSomeCoding)| Design with React| 1-Begineer |
 | [TIC TAC TOE](https://www.youtube.com/watch?v=BHh654_7Cmw) | Tic Tac Toe game using Python| 1-Beginner |
 | [Password Generator](https://www.youtube.com/watch?v=SwgBZ0BQNLQ) | Password Generator App using Python| 1-Beginner |
 | [PDF to Audio Book Converter](https://www.youtube.com/watch?v=kyZ_5cvrXJI&list=WL&index=18) | PDF to Audio Book using Python| 1-Beginner |


### PR DESCRIPTION
Fixed markdown syntax for Tier 1 section which was causing the table to be not rendered as intended.

![image](https://github.com/user-attachments/assets/bd230f88-7f19-40d2-a7b1-a358eeb1f045)

An in the above image the lower half of the table was not rendered properly because of a syntax mistake. This PR fixes the syntax so the table is now rendered as it should.

![image](https://github.com/user-attachments/assets/b9e9539e-de91-475c-9e4b-ccee388c5ddd)
